### PR TITLE
wiki lint: honor a SCHEMA.md lint-exclude directive for non-page folders

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -20,7 +20,7 @@
         "path": "./plugins/knowledge_management"
       },
       "description": "Skills and agents for building, maintaining, and distilling a persistent, interlinked knowledge base. Ships the wiki, wiki_wrapup, wiki_import, wiki_fix, executive_summary, and spr skills, and the auto_shaper_wiki agent.",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "knowledge_management",
       "source": "./plugins/knowledge_management",
       "description": "Skills and agents for building, maintaining, and distilling a persistent, interlinked knowledge base. Ships the wiki, wiki_wrapup, wiki_import, wiki_fix, executive_summary, and spr skills, and the auto_shaper_wiki agent.",
-      "version": "1.10.4"
+      "version": "1.10.5"
     },
     {
       "name": "ai_dev",

--- a/plugins/knowledge_management/.claude-plugin/plugin.json
+++ b/plugins/knowledge_management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge_management",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Skills and agents for building, maintaining, and distilling a persistent, interlinked knowledge base. Ships the wiki, wiki_wrapup, wiki_import, wiki_fix, executive_summary, and spr skills, and the auto_shaper_wiki agent.",
   "author": { "name": "Andreas F. Hoffmann" },
   "license": "MIT"

--- a/plugins/knowledge_management/.codex-plugin/plugin.json
+++ b/plugins/knowledge_management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge_management",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Skills and agents for building, maintaining, and distilling a persistent, interlinked knowledge base. Ships the wiki, wiki_wrapup, wiki_import, wiki_fix, executive_summary, and spr skills, and the auto_shaper_wiki agent.",
   "author": { "name": "Andreas F. Hoffmann" },
   "license": "MIT",

--- a/plugins/knowledge_management/agents/auto_shaper_wiki.md
+++ b/plugins/knowledge_management/agents/auto_shaper_wiki.md
@@ -1,7 +1,7 @@
 ---
 name: auto_shaper_wiki
 description: Audits the wiki of the current repository end-to-end, runs the linter, and autonomously fixes every issue found — including frontmatter and schema violations, broken links, off-taxonomy tags, oversized or topic-mixing pages that need splitting, procedure pages that leak instance content, procedure pages that read as descriptions of a mechanism rather than steps for an operator, clear content violations of the page-type anatomy, and contradictions between wiki pages (surfaced via the contested-page protocol rather than auto-resolved). Use when the user asks to audit, lint, fix, health-check, clean up, or auto-repair their wiki.
-version: 1.7.3
+version: 1.7.4
 model: inherit
 background: false
 effort: high
@@ -58,8 +58,8 @@ exists so the SCHEMA read is never skipped or deferred.
     the current canonical structure encoded in `$WIKI_SKILL/SKILL.md`
     and `$WIKI_SKILL/references/template_*.md`. The wiki's own
     customizations (configured domain, tag taxonomy, declared custom
-    fields, user-added page types) are preserved on top of the
-    canonical baseline.
+    fields, user-added page types, page-check exclusions) are
+    preserved on top of the canonical baseline.
   </scaffold_alignment>
   <index_completeness>
     `index.md` lists every page exactly once under its correct section.
@@ -508,7 +508,8 @@ the fix move.
       drift on the surrounding scaffold:
 
       - `template_schema.md`: the body of `## Domain`, the body of
-        `## Tag Taxonomy`, declared custom frontmatter fields beyond
+        `## Tag Taxonomy`, the `Page-check exclusions` bullet in the
+        `## Lint` section, declared custom frontmatter fields beyond
         the canonical set, and user-added page types beyond the
         canonical enum.
       - `template_index.md`: the header values (`Total pages: N`,
@@ -1086,8 +1087,9 @@ affect the same file so each file is opened, read, and rewritten once.
     frontmatter) as the skill evolves. Bring the scaffold forward to
     match the current `$WIKI_SKILL/SKILL.md` and
     `$WIKI_SKILL/references/template_*.md`, preserving the wiki's
-    domain, tag taxonomy, declared custom fields, and user-added page
-    types on top. The references are read-as-canonical, never edited.
+    domain, tag taxonomy, declared custom fields, user-added page
+    types, and page-check exclusions on top. The references are
+    read-as-canonical, never edited.
   </scaffold_alignment_is_in_scope>
 
   <drive_scaffold_check_from_diff>

--- a/plugins/knowledge_management/skills/wiki/SKILL.md
+++ b/plugins/knowledge_management/skills/wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wiki
 description: Activate this skill whenever the user mentions their wiki, knowledge base, or research notes in any way — including queries that compare, contrast, reference, analyze, or discuss wiki content rather than ask to edit it. Build and maintain a persistent, compounding knowledge base of interlinked plain markdown files. Use when the user asks to create, build, start, or initialize a wiki or knowledge base; add, create, or write wiki pages; query, compare, contrast, reference, or analyze an existing wiki to answer a research or domain question; archive or reorganize wiki pages; or whenever the user names the wiki, the knowledge base, or their notes in the current request even as a passing reference.
-version: 1.16.1
+version: 1.16.2
 author: Andreas F. Hoffmann
 license: MIT
 ---

--- a/plugins/knowledge_management/skills/wiki/references/lint_checks.md
+++ b/plugins/knowledge_management/skills/wiki/references/lint_checks.md
@@ -24,6 +24,10 @@ Reference for `scripts/lint.py` — what each check catches and which severity b
 | markdown style | bullet style (`-` only); header level skipping; trailing punctuation in headers; fenced code without language identifier; multiple consecutive blank lines; bare URLs; list-marker spacing; trailing newline (matches the `format_markdown` skill) |
 | wikilink | `[[target]]` or `[[target\|alias]]` wikilink-style references outside of fenced code blocks and inline code. The wiki uses standard markdown links `[text](relative/path.md)` so cross-references resolve in plain renderers and feed the broken-link check; the warning includes a hint suggesting the equivalent markdown form. |
 
+## Page-walk scope
+
+The per-page checks (frontmatter, links, structure, orphans, tags, size, and the rest) run on every Markdown file under the type folders. The walk always skips the `raw/` and `_archive/` trees; a vault extends that skip set by listing extra top-level directories on a `- Page-check exclusions: a, b` bullet in `SCHEMA.md`'s `## Lint` section (documented in `template_schema.md`). The names are read only outside fenced code blocks, so a documented example never becomes a live exclusion.
+
 ## Severity buckets
 
 - **blocking** — broken links, broken `sources:` frontmatter entries, missing or malformed frontmatter, missing `index.md`, missing or unparseable `SCHEMA.md`, pages filed outside their `<type>s/<slug>.md` location. The script exits 1 while any blocking finding remains.

--- a/plugins/knowledge_management/skills/wiki/references/template_schema.md
+++ b/plugins/knowledge_management/skills/wiki/references/template_schema.md
@@ -240,3 +240,22 @@ When new information conflicts with existing content:
 2. If genuinely contradictory, note both positions with dates and sources
 3. Mark the contradiction in frontmatter: `contradictions: [page-name]`
 4. Flag for user review in the lint report
+
+## Lint
+
+`scripts/lint.py` walks every Markdown file under the type folders and always
+skips the `raw/` and `_archive/` trees. A vault that also holds non-page
+folders — synced notes, generated artifacts, imported working files — names
+them here so the page rules (frontmatter, links, structure, orphans) stay off
+files that were never meant to be wiki pages:
+
+```text
+- Page-check exclusions: notes, generated
+```
+
+List the directory names directly under the wiki root, comma-separated, on one
+`Page-check exclusions:` bullet. The names are additive to the always-skipped
+`raw/` and `_archive/`, not a replacement. Omit the bullet when the vault holds
+only pages — the default skips the two standard trees and nothing else. The
+linter reads this bullet only outside fenced code blocks, so the example above
+is documentation rather than a live setting.

--- a/plugins/knowledge_management/skills/wiki/scripts/lint.py
+++ b/plugins/knowledge_management/skills/wiki/scripts/lint.py
@@ -245,6 +245,20 @@ def parse_frontmatter(text: str) -> tuple[dict | None, str]:
 # File iteration
 # ---------------------------------------------------------------------------
 
+def load_excluded_roots(wiki: Path) -> set[str]:
+    """Roots to skip during the page walk. Always skips ``raw`` and
+    ``_archive``; extra roots come from a ``<!-- lint-exclude: a, b -->``
+    directive in SCHEMA.md (comma-separated dir names). Absent directive =
+    default behaviour, so existing vaults are unaffected."""
+    roots = {"raw", "_archive"}
+    schema = wiki / "SCHEMA.md"
+    if schema.is_file():
+        m = re.search(r"<!--\s*lint-exclude:\s*([^>]*?)-->", schema.read_text())
+        if m:
+            roots |= {p.strip() for p in m.group(1).split(",") if p.strip()}
+    return roots
+
+
 def iter_wiki_pages(wiki: Path) -> Iterator[Path]:
     """Yield every page in the wiki, regardless of folder organization.
 
@@ -253,7 +267,7 @@ def iter_wiki_pages(wiki: Path) -> Iterator[Path]:
     root (SCHEMA.md, index.md, log.md and any other root-level markdown),
     the ``raw/`` source tree, the ``_archive/`` tree, and hidden directories.
     """
-    excluded_roots = {"raw", "_archive"}
+    excluded_roots = load_excluded_roots(wiki)
     for path in sorted(wiki.rglob("*.md")):
         if path.parent == wiki:
             continue

--- a/plugins/knowledge_management/skills/wiki/scripts/lint.py
+++ b/plugins/knowledge_management/skills/wiki/scripts/lint.py
@@ -245,17 +245,52 @@ def parse_frontmatter(text: str) -> tuple[dict | None, str]:
 # File iteration
 # ---------------------------------------------------------------------------
 
+# A single bullet in SCHEMA.md's ``## Lint`` section names extra top-level
+# directories to skip during the page walk: ``- Page-check exclusions: a, b``
+# (comma-separated dir names directly under the wiki root). ``-``/``*``/``+``
+# are all accepted as the marker; the label is matched case-insensitively.
+LINT_EXCLUDE_RE = re.compile(
+    r"^\s*[-*+]\s+page-check exclusions\s*:\s*(.+)$",
+    re.IGNORECASE,
+)
+
+
 def load_excluded_roots(wiki: Path) -> set[str]:
-    """Roots to skip during the page walk. Always skips ``raw`` and
-    ``_archive``; extra roots come from a ``<!-- lint-exclude: a, b -->``
-    directive in SCHEMA.md (comma-separated dir names). Absent directive =
-    default behaviour, so existing vaults are unaffected."""
+    """Top-level directory names to skip during the page walk.
+
+    Always skips ``raw`` and ``_archive``. A wiki adds more by listing them
+    on a ``- Page-check exclusions: a, b`` bullet inside a ``## Lint``
+    section in SCHEMA.md — directory names directly under the wiki root,
+    comma-separated, additive to the two defaults. A vault that mixes
+    curated pages with operational or imported subtrees keeps the page rules
+    off those trees this way.
+
+    The scan is scoped to the ``## Lint`` section and skips fenced code
+    blocks within it, mirroring ``load_taxonomy`` and the body scanners — so
+    the bullet shown inside a fenced example (in the canonical template, or
+    where a vault documents its own list) is never read as live config.
+    Absent section or bullet leaves the default ``{raw, _archive}``
+    unchanged, so existing vaults are unaffected.
+    """
     roots = {"raw", "_archive"}
     schema = wiki / "SCHEMA.md"
-    if schema.is_file():
-        m = re.search(r"<!--\s*lint-exclude:\s*([^>]*?)-->", schema.read_text())
+    if not schema.is_file():
+        return roots
+    section = re.search(
+        r"##\s+Lint(.+?)(?=\n##\s|\Z)", schema.read_text(encoding="utf-8"), re.DOTALL
+    )
+    if not section:
+        return roots
+    in_fence = False
+    for line in section.group(1).splitlines():
+        if FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = LINT_EXCLUDE_RE.match(line)
         if m:
-            roots |= {p.strip() for p in m.group(1).split(",") if p.strip()}
+            roots |= {p.strip().strip("`*_'\"") for p in m.group(1).split(",") if p.strip()}
     return roots
 
 


### PR DESCRIPTION
## The problem

The linter checks every Markdown file in the vault. It always skips `raw/` and `_archive/`, but that skip list is fixed in the code — there's no way to add to it.

Plenty of vaults hold more than wiki pages: synced notes, working files, generated artifacts. The linter can't skip those folders, so it runs the page rules (frontmatter, link checks, structure, orphans) on files that were never meant to be wiki pages, and flags them as errors.

## The change

Let a vault name extra folders to skip, in a one-line comment in `SCHEMA.md`:

```
<!-- lint-exclude: folder-a, folder-b -->
```

The linter reads that line and skips those folders too, on top of `raw/` and `_archive/`. It's one small helper plus one changed line.

## Nothing changes for existing vaults

No directive → the linter behaves exactly as it does today. So this is safe to merge.

## Why put it in `SCHEMA.md`

*Which* folders to skip is a fact about the vault, not about how you run the command — and it should survive plugin updates. `SCHEMA.md` already holds the vault's other rules (page types, tags, custom fields), so the skip list belongs there too, not in a command flag or a separate config file.

## How I tested it

Ran it on a real, multi-folder vault. With the directive set, the linter stopped flagging the skipped folders (normal pages still checked) and the error count went to zero. With no directive, the output is byte-identical to current `main`.
